### PR TITLE
fix(initFromCode): copy code string from parameter to property

### DIFF
--- a/Classes/GeoHexV2.h
+++ b/Classes/GeoHexV2.h
@@ -23,7 +23,7 @@
 	MKMapPoint position;				
 }
 
-@property(nonatomic, retain, readonly) NSString *code;	/*!< The encoded string for this GeoHex. */
+@property(nonatomic, copy, readonly) NSString *code;	/*!< The encoded string for this GeoHex. */
 @property(readonly) CLLocationCoordinate2D coordinate;	/*!< The coordinate of the GeoHex. */
 @property(readonly) MKMapPoint position;				/*!< The X, Y position of the GeoHex, using the GeoHex specific coordinate system */
 

--- a/Classes/GeoHexV3.h
+++ b/Classes/GeoHexV3.h
@@ -23,7 +23,7 @@
 	MKMapPoint position;				
 }
 
-@property(nonatomic, retain, readonly) NSString *code;	/*!< The encoded string for this GeoHex. */
+@property(nonatomic, copy, readonly) NSString *code;	/*!< The encoded string for this GeoHex. */
 @property(readonly) CLLocationCoordinate2D coordinate;	/*!< The coordinate of the GeoHex. */
 @property(readonly) MKMapPoint position;				/*!< The X, Y position of the GeoHex, using the GeoHex specific coordinate system */
 

--- a/Classes/GeoHexV3.m
+++ b/Classes/GeoHexV3.m
@@ -173,7 +173,7 @@
             h_y -= pow(3,level);
         }
         
-        code = aCode;
+        code = [aCode copy];
         coordinate = h_loc;
         position = MKMapPointMake(h_x, h_y);
 	}


### PR DESCRIPTION
Double memory release problem.

When caller provides `aCode` parameter to  `initFromCode` method by variable, this problem occurs.
So this need to copy memory when `initFromCode` is called.